### PR TITLE
Fix Lua 5.1/Love2D support + Changed way of requiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Usage
 -----
 You can call a hook anywhere in your code and create an event to hook.
 ```lua
+hooker = require "hooker"
+
 function computeDistance(a,b)
 	hooker.Call("preComputeDistance", a, b)
 	--[[

--- a/hooker.lua
+++ b/hooker.lua
@@ -10,6 +10,10 @@ local hooker = {
 }
 -- this is where we store our hooks and the things that latch on to them like greedy little hellions
 
+local function pack(...)
+	return {n = select('#', ...), ...}
+end
+
 function hooker.Add( eventName, identifier, func )
 	--string, any, function
 	if hooker.hookTable[eventName]==nil then
@@ -26,7 +30,7 @@ function hooker.Call( eventName, ... )
 	else
 		local results
 		for identifier,func in hooker.hookIter(hooker.hookTable[eventName]) do
-			results = table.pack(func(...))
+			results = pack(func(...))
 			results.n = nil
 			if #results>0 then
 				-- potential problems if relying on sandwiching a nil in the return results

--- a/hooker.lua
+++ b/hooker.lua
@@ -3,7 +3,7 @@
 	https://github.com/EntranceJew/hooker
 ]]
 
-hooker = {
+local hooker = {
 	hookTable = {},
 	hookIter = pairs
 	-- override this if you want globally deterministic hook iteration
@@ -56,3 +56,5 @@ function hooker.Remove( eventName, identifier )
 	hooker.hookTable[eventName] = nil
 	return true
 end
+
+return hooker


### PR DESCRIPTION
Lua 5.1 and Love2D don't come with table.pack() so I have added the equivalent into the script.

I have also changed the way of requiring so this:

``` lua
require "hooker"
```

Becomes this:

``` lua
hooker = require "hooker"
```

as this is better practice.  
