### PR TITLE
Fix hooker.GetTable()

### DIFF
--- a/hooker.lua
+++ b/hooker.lua
@@ -41,7 +41,7 @@ function hooker.Call( eventName, ... )
 end
 
 function hooker.GetTable()
-	return hooker.hookTable()
+	return hooker.hookTable
 end
 
 function hooker.Remove( eventName, identifier )


### PR DESCRIPTION
hooker.GetTable() was trying to call hooker.hookTable as a function (which is a table so it causes an error)
